### PR TITLE
refactor: extract config and tracing helpers

### DIFF
--- a/cmd/wrapper/main.go
+++ b/cmd/wrapper/main.go
@@ -1,131 +1,79 @@
 package main
 
 import (
-	"bufio"
 	"context"
-	"encoding/json"
-	"fmt"
 	"log"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"time"
 
 	"github.com/google/uuid"
-	"go.opentelemetry.io/otel"
+
+	"sling-sync-wrapper/internal/config"
+	"sling-sync-wrapper/internal/tracing"
+
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
-	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 )
-
-type SlingLogLine struct {
-	Level   string `json:"level"`
-	Message string `json:"message"`
-	Rows    int    `json:"rows,omitempty"`
-	Error   string `json:"error,omitempty"`
-}
-
-// getEnv fetches an environment variable or returns a fallback value
-func getEnv(key, fallback string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return fallback
-}
 
 func main() {
 	ctx := context.Background()
 
-	// --- Env variables ---
-	missionClusterID := getEnv("MISSION_CLUSTER_ID", "unknown-cluster")
-	pipelineFile := os.Getenv("SLING_CONFIG")
-	pipelineDir := os.Getenv("PIPELINE_DIR") // directory support
-	stateLocation := getEnv("SLING_STATE", "file://./sling_state.json")
-	otelEndpoint := getEnv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4317")
-	syncMode := getEnv("SYNC_MODE", "normal") // normal, noop, backfill
-	maxRetries := getEnvInt("SYNC_MAX_RETRIES", 3)
-	backoffBase := getEnvDuration("SYNC_BACKOFF_BASE", 5*time.Second)
+	cfg := config.FromEnv()
 
-	// --- Init OTel ---
-	exp, err := otlptracegrpc.New(ctx,
-		otlptracegrpc.WithInsecure(),
-		otlptracegrpc.WithEndpoint(otelEndpoint))
+	pipelines, err := config.Pipelines(cfg)
 	if err != nil {
-		log.Fatalf("failed to create OTLP trace exporter: %v", err)
+		log.Fatal(err)
 	}
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(exp),
-		sdktrace.WithResource(resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("sling-sync-wrapper"),
-			attribute.String("mission_cluster_id", missionClusterID),
-		)),
-	)
-	defer tp.Shutdown(ctx)
-	otel.SetTracerProvider(tp)
-	tracer := otel.Tracer("sling-sync-wrapper")
 
-	// --- Choose pipelines (single file or directory) ---
-	var pipelines []string
-	if pipelineDir != "" {
-		files, _ := filepath.Glob(filepath.Join(pipelineDir, "*.yaml"))
-		pipelines = append(pipelines, files...)
-	} else if pipelineFile != "" {
-		pipelines = append(pipelines, pipelineFile)
-	} else {
-		log.Fatal("No SLING_CONFIG or PIPELINE_DIR specified")
-	}
+	tracer, shutdown := tracing.Init(ctx, "sling-sync-wrapper", cfg.MissionClusterID, cfg.OTELEndpoint)
+	defer shutdown(ctx)
 
 	for _, pipeline := range pipelines {
 		jobID := uuid.NewString()
 		os.Setenv("SYNC_JOB_ID", jobID)
 		os.Setenv("SLING_CONFIG", pipeline)
-		runPipeline(ctx, tracer, missionClusterID, pipeline, stateLocation, jobID, syncMode, maxRetries, backoffBase)
+		runPipeline(ctx, tracer, cfg, pipeline, jobID)
 	}
 }
 
-func runPipeline(ctx context.Context, tracer trace.Tracer, missionClusterID, pipeline, stateLocation, jobID, syncMode string, maxRetries int, backoffBase time.Duration) {
+func runPipeline(ctx context.Context, tracer trace.Tracer, cfg config.Config, pipeline, jobID string) {
 	ctx, span := tracer.Start(ctx, "sling.sync.run")
+	defer span.End()
+
 	span.SetAttributes(
-		attribute.String("mission_cluster_id", missionClusterID),
+		attribute.String("mission_cluster_id", cfg.MissionClusterID),
 		attribute.String("sync_job_id", jobID),
 		attribute.String("pipeline", pipeline),
-		attribute.String("state_location", stateLocation),
-		attribute.String("sync_mode", syncMode),
+		attribute.String("state_location", cfg.StateLocation),
+		attribute.String("sync_mode", cfg.SyncMode),
 	)
 
 	startTime := time.Now()
 
-	// Noop mode
-	if syncMode == "noop" {
+	if cfg.SyncMode == "noop" {
 		log.Printf("[NOOP] Would run Sling pipeline %s", pipeline)
 		span.SetAttributes(attribute.String("status", "noop"))
-		span.End()
 		return
 	}
 
-	// Backfill mode → reset state
-	if syncMode == "backfill" {
-		log.Printf("[BACKFILL] Resetting sync state at %s", stateLocation)
-		if err := os.RemoveAll(stateLocation); err != nil {
+	if cfg.SyncMode == "backfill" {
+		log.Printf("[BACKFILL] Resetting sync state at %s", cfg.StateLocation)
+		if err := os.RemoveAll(cfg.StateLocation); err != nil {
 			log.Printf("Failed to reset state: %v", err)
 		}
 	}
 
 	var lastErr error
 	var rowsSynced int
-	for attempt := 1; attempt <= maxRetries; attempt++ {
-		rows, err := runSlingOnce(ctx, pipeline, stateLocation, jobID, span)
+	for attempt := 1; attempt <= cfg.MaxRetries; attempt++ {
+		rows, err := runSlingOnce(ctx, pipeline, cfg.StateLocation, jobID, span)
 		rowsSynced += rows
 		if err == nil {
 			lastErr = nil
 			break
 		}
 		lastErr = err
-		wait := time.Duration(attempt) * backoffBase
+		wait := time.Duration(attempt) * cfg.BackoffBase
 		log.Printf("Attempt %d failed: %v, retrying in %s", attempt, err, wait)
 		time.Sleep(wait)
 	}
@@ -141,71 +89,6 @@ func runPipeline(ctx context.Context, tracer trace.Tracer, missionClusterID, pip
 	} else {
 		span.SetAttributes(attribute.String("status", "success"))
 	}
-	span.End()
+
 	log.Printf("Pipeline %s completed in %.2fs (rows: %d, status: %s)", pipeline, duration.Seconds(), rowsSynced, statusFromErr(lastErr))
-}
-
-func runSlingOnce(ctx context.Context, pipeline, stateLocation, jobID string, span trace.Span) (int, error) {
-	cmd := exec.CommandContext(ctx, "sling", "sync", "--config", pipeline, "--log-format", "json")
-	cmd.Env = append(os.Environ(), fmt.Sprintf("SLING_STATE=%s", stateLocation))
-
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return 0, err
-	}
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Start(); err != nil {
-		return 0, err
-	}
-
-	scanner := bufio.NewScanner(stdout)
-	rowsSynced := 0
-	for scanner.Scan() {
-		line := scanner.Text()
-		var logEntry SlingLogLine
-		if err := json.Unmarshal([]byte(line), &logEntry); err == nil {
-			span.AddEvent(logEntry.Message,
-				trace.WithAttributes(attribute.String("log.level", logEntry.Level)))
-			if logEntry.Rows > 0 {
-				rowsSynced += logEntry.Rows
-			}
-			if logEntry.Error != "" {
-				span.RecordError(fmt.Errorf("%s", logEntry.Error))
-			}
-		} else {
-			span.AddEvent(line)
-		}
-	}
-
-	if err := cmd.Wait(); err != nil {
-		return rowsSynced, err
-	}
-	return rowsSynced, nil
-}
-
-func statusFromErr(err error) string {
-	if err != nil {
-		return "failed"
-	}
-	return "success"
-}
-
-// Helpers for environment conversion
-func getEnvInt(key string, fallback int) int {
-	if v := os.Getenv(key); v != "" {
-		var i int
-		fmt.Sscanf(v, "%d", &i)
-		return i
-	}
-	return fallback
-}
-
-func getEnvDuration(key string, fallback time.Duration) time.Duration {
-	if v := os.Getenv(key); v != "" {
-		if d, err := time.ParseDuration(v); err == nil {
-			return d
-		}
-	}
-	return fallback
 }

--- a/cmd/wrapper/sling.go
+++ b/cmd/wrapper/sling.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// SlingLogLine represents a single JSON log entry from the Sling CLI.
+type SlingLogLine struct {
+	Level   string `json:"level"`
+	Message string `json:"message"`
+	Rows    int    `json:"rows,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+func runSlingOnce(ctx context.Context, pipeline, stateLocation, jobID string, span trace.Span) (int, error) {
+	cmd := exec.CommandContext(ctx, "sling", "sync", "--config", pipeline, "--log-format", "json")
+	cmd.Env = append(os.Environ(), fmt.Sprintf("SLING_STATE=%s", stateLocation))
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return 0, err
+	}
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return 0, err
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	rowsSynced := 0
+	for scanner.Scan() {
+		line := scanner.Text()
+		var logEntry SlingLogLine
+		if err := json.Unmarshal([]byte(line), &logEntry); err == nil {
+			span.AddEvent(logEntry.Message,
+				trace.WithAttributes(attribute.String("log.level", logEntry.Level)))
+			if logEntry.Rows > 0 {
+				rowsSynced += logEntry.Rows
+			}
+			if logEntry.Error != "" {
+				span.RecordError(fmt.Errorf("%s", logEntry.Error))
+			}
+		} else {
+			span.AddEvent(line)
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return rowsSynced, err
+	}
+	return rowsSynced, nil
+}
+
+func statusFromErr(err error) string {
+	if err != nil {
+		return "failed"
+	}
+	return "success"
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Config holds all runtime configuration loaded from environment variables.
+type Config struct {
+	MissionClusterID string
+	PipelineFile     string
+	PipelineDir      string
+	StateLocation    string
+	OTELEndpoint     string
+	SyncMode         string
+	MaxRetries       int
+	BackoffBase      time.Duration
+}
+
+// FromEnv constructs a Config from environment variables.
+func FromEnv() Config {
+	return Config{
+		MissionClusterID: getEnv("MISSION_CLUSTER_ID", "unknown-cluster"),
+		PipelineFile:     os.Getenv("SLING_CONFIG"),
+		PipelineDir:      os.Getenv("PIPELINE_DIR"),
+		StateLocation:    getEnv("SLING_STATE", "file://./sling_state.json"),
+		OTELEndpoint:     getEnv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4317"),
+		SyncMode:         getEnv("SYNC_MODE", "normal"),
+		MaxRetries:       getEnvInt("SYNC_MAX_RETRIES", 3),
+		BackoffBase:      getEnvDuration("SYNC_BACKOFF_BASE", 5*time.Second),
+	}
+}
+
+// Pipelines returns a list of pipeline files to run.
+func Pipelines(cfg Config) ([]string, error) {
+	var pipelines []string
+	if cfg.PipelineDir != "" {
+		files, err := filepath.Glob(filepath.Join(cfg.PipelineDir, "*.yaml"))
+		if err != nil {
+			return nil, err
+		}
+		pipelines = append(pipelines, files...)
+	} else if cfg.PipelineFile != "" {
+		pipelines = append(pipelines, cfg.PipelineFile)
+	} else {
+		return nil, fmt.Errorf("no SLING_CONFIG or PIPELINE_DIR specified")
+	}
+	return pipelines, nil
+}
+
+func getEnv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func getEnvInt(key string, fallback int) int {
+	if v := os.Getenv(key); v != "" {
+		var i int
+		fmt.Sscanf(v, "%d", &i)
+		return i
+	}
+	return fallback
+}
+
+func getEnvDuration(key string, fallback time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return fallback
+}

--- a/internal/tracing/tracer.go
+++ b/internal/tracing/tracer.go
@@ -1,0 +1,35 @@
+package tracing
+
+import (
+	"context"
+	"log"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Init sets up an OTEL tracer and returns it along with a shutdown function.
+func Init(ctx context.Context, serviceName, missionClusterID, endpoint string) (trace.Tracer, func(context.Context) error) {
+	exp, err := otlptracegrpc.New(ctx,
+		otlptracegrpc.WithInsecure(),
+		otlptracegrpc.WithEndpoint(endpoint))
+	if err != nil {
+		log.Fatalf("failed to create OTLP trace exporter: %v", err)
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exp),
+		sdktrace.WithResource(resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceNameKey.String(serviceName),
+			attribute.String("mission_cluster_id", missionClusterID),
+		)),
+	)
+	otel.SetTracerProvider(tp)
+	return tp.Tracer(serviceName), tp.Shutdown
+}


### PR DESCRIPTION
## Summary
- reduce size of main.go by moving helper logic out
- add `internal/config` for environment parsing
- add `internal/tracing` to encapsulate OTel setup
- move Sling execution helpers to `sling.go`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6887cd64e9fc832386613bb29e3ad71d