### PR TITLE
tests(codex): add basic tests and refactor for testability

### DIFF
--- a/cmd/wrapper/main.go
+++ b/cmd/wrapper/main.go
@@ -15,6 +15,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+var runSlingOnceFunc = runSlingOnce
+
 func main() {
 	ctx := context.Background()
 
@@ -66,7 +68,7 @@ func runPipeline(ctx context.Context, tracer trace.Tracer, cfg config.Config, pi
 	var lastErr error
 	var rowsSynced int
 	for attempt := 1; attempt <= cfg.MaxRetries; attempt++ {
-		rows, err := runSlingOnce(ctx, pipeline, cfg.StateLocation, jobID, span)
+		rows, err := runSlingOnceFunc(ctx, pipeline, cfg.StateLocation, jobID, span)
 		rowsSynced += rows
 		if err == nil {
 			lastErr = nil

--- a/cmd/wrapper/pipeline_test.go
+++ b/cmd/wrapper/pipeline_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+	"sling-sync-wrapper/internal/config"
+)
+
+func TestRunPipelineNoop(t *testing.T) {
+	var called bool
+	runSlingOnceFunc = func(ctx context.Context, pipeline, state, jobID string, span trace.Span) (int, error) {
+		called = true
+		return 0, nil
+	}
+	defer func() { runSlingOnceFunc = runSlingOnce }()
+
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	tracer := tp.Tracer("test")
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	cfg := config.Config{MissionClusterID: "mc", StateLocation: "state", SyncMode: "noop", MaxRetries: 1, BackoffBase: time.Millisecond}
+	runPipeline(context.Background(), tracer, cfg, "pipe.yaml", "job1")
+
+	if called {
+		t.Fatalf("runSlingOnce should not be called in noop mode")
+	}
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("expected one span, got %d", len(spans))
+	}
+	found := false
+	for _, attr := range spans[0].Attributes() {
+		if attr.Key == "status" && attr.Value.AsString() == "noop" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("noop status attribute missing")
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("[NOOP]")) {
+		t.Errorf("noop log not produced")
+	}
+}

--- a/cmd/wrapper/sling.go
+++ b/cmd/wrapper/sling.go
@@ -12,6 +12,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+var execCommandContext = exec.CommandContext
+
 // SlingLogLine represents a single JSON log entry from the Sling CLI.
 type SlingLogLine struct {
 	Level   string `json:"level"`
@@ -21,7 +23,7 @@ type SlingLogLine struct {
 }
 
 func runSlingOnce(ctx context.Context, pipeline, stateLocation, jobID string, span trace.Span) (int, error) {
-	cmd := exec.CommandContext(ctx, "sling", "sync", "--config", pipeline, "--log-format", "json")
+	cmd := execCommandContext(ctx, "sling", "sync", "--config", pipeline, "--log-format", "json")
 	cmd.Env = append(os.Environ(), fmt.Sprintf("SLING_STATE=%s", stateLocation))
 
 	stdout, err := cmd.StdoutPipe()

--- a/cmd/wrapper/sling_test.go
+++ b/cmd/wrapper/sling_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func fakeExecCommandContext(script string) func(context.Context, string, ...string) *exec.Cmd {
+	return func(ctx context.Context, command string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, script)
+	}
+}
+
+func writeScript(dir string) (string, error) {
+	script := filepath.Join(dir, "sling")
+	content := "#!/bin/sh\n" +
+		"echo '{\"level\":\"info\",\"message\":\"start\"}'\n" +
+		"echo '{\"level\":\"info\",\"message\":\"rows\",\"rows\":10}'\n" +
+		"echo '{\"level\":\"error\",\"message\":\"fail\",\"error\":\"boom\"}'\n"
+	if err := os.WriteFile(script, []byte(content), 0755); err != nil {
+		return "", err
+	}
+	return script, nil
+}
+
+func TestRunSlingOnceEvents(t *testing.T) {
+	dir := t.TempDir()
+	script, err := writeScript(dir)
+	if err != nil {
+		t.Fatalf("script: %v", err)
+	}
+	execCommandContext = fakeExecCommandContext(script)
+	defer func() { execCommandContext = exec.CommandContext }()
+
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	tracer := tp.Tracer("test")
+
+	ctx := context.Background()
+	ctx, span := tracer.Start(ctx, "run")
+	rows, err := runSlingOnce(ctx, "pipe.yaml", "state", "job", span)
+	span.End()
+	if err != nil {
+		t.Fatalf("runSlingOnce error: %v", err)
+	}
+	if rows != 10 {
+		t.Fatalf("expected 10 rows, got %d", rows)
+	}
+
+	ended := sr.Ended()
+	if len(ended) != 1 {
+		t.Fatalf("expected one span, got %d", len(ended))
+	}
+	if len(ended[0].Events()) < 3 {
+		t.Errorf("expected at least 3 events, got %d", len(ended[0].Events()))
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFromEnvDefaults(t *testing.T) {
+	os.Clearenv()
+	cfg := FromEnv()
+	if cfg.MissionClusterID != "unknown-cluster" {
+		t.Errorf("expected default MissionClusterID, got %s", cfg.MissionClusterID)
+	}
+	if cfg.StateLocation != "file://./sling_state.json" {
+		t.Errorf("unexpected default state location: %s", cfg.StateLocation)
+	}
+	if cfg.OTELEndpoint != "localhost:4317" {
+		t.Errorf("unexpected default OTEL endpoint: %s", cfg.OTELEndpoint)
+	}
+	if cfg.SyncMode != "normal" {
+		t.Errorf("unexpected default sync mode: %s", cfg.SyncMode)
+	}
+	if cfg.MaxRetries != 3 {
+		t.Errorf("unexpected default retries: %d", cfg.MaxRetries)
+	}
+	if cfg.BackoffBase != 5*time.Second {
+		t.Errorf("unexpected default backoff: %s", cfg.BackoffBase)
+	}
+}
+
+func TestFromEnvOverrides(t *testing.T) {
+	t.Setenv("MISSION_CLUSTER_ID", "mc1")
+	t.Setenv("SLING_CONFIG", "pipeline.yaml")
+	t.Setenv("SLING_STATE", "state.json")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "otel:4317")
+	t.Setenv("SYNC_MODE", "backfill")
+	t.Setenv("SYNC_MAX_RETRIES", "5")
+	t.Setenv("SYNC_BACKOFF_BASE", "2s")
+
+	cfg := FromEnv()
+	if cfg.MissionClusterID != "mc1" || cfg.PipelineFile != "pipeline.yaml" {
+		t.Errorf("unexpected cfg: %+v", cfg)
+	}
+	if cfg.StateLocation != "state.json" || cfg.SyncMode != "backfill" {
+		t.Errorf("unexpected cfg values: %+v", cfg)
+	}
+	if cfg.MaxRetries != 5 || cfg.BackoffBase != 2*time.Second {
+		t.Errorf("unexpected retry/backoff: %+v", cfg)
+	}
+	if cfg.OTELEndpoint != "otel:4317" {
+		t.Errorf("unexpected otel endpoint: %s", cfg.OTELEndpoint)
+	}
+}
+
+func TestPipelinesFile(t *testing.T) {
+	cfg := Config{PipelineFile: "p1.yaml"}
+	files, err := Pipelines(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(files) != 1 || files[0] != "p1.yaml" {
+		t.Errorf("unexpected files: %v", files)
+	}
+}
+
+func TestPipelinesDir(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "a.yaml")
+	f2 := filepath.Join(dir, "b.yaml")
+	os.WriteFile(f1, []byte("a"), 0644)
+	os.WriteFile(f2, []byte("b"), 0644)
+
+	files, err := Pipelines(Config{PipelineDir: dir})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files, got %v", files)
+	}
+}
+
+func TestPipelinesMissing(t *testing.T) {
+	_, err := Pipelines(Config{})
+	if err == nil {
+		t.Fatalf("expected error for missing config")
+	}
+}

--- a/internal/tracing/tracer_test.go
+++ b/internal/tracing/tracer_test.go
@@ -1,0 +1,50 @@
+package tracing
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	collectortrace "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	"google.golang.org/grpc"
+)
+
+type otlpServer struct {
+	collectortrace.UnimplementedTraceServiceServer
+	mu       sync.Mutex
+	requests []*collectortrace.ExportTraceServiceRequest
+}
+
+func (s *otlpServer) Export(ctx context.Context, req *collectortrace.ExportTraceServiceRequest) (*collectortrace.ExportTraceServiceResponse, error) {
+	s.mu.Lock()
+	s.requests = append(s.requests, req)
+	s.mu.Unlock()
+	return &collectortrace.ExportTraceServiceResponse{}, nil
+}
+
+func TestInit(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server := grpc.NewServer()
+	otlp := &otlpServer{}
+	collectortrace.RegisterTraceServiceServer(server, otlp)
+	go server.Serve(lis)
+	defer server.Stop()
+
+	tracer, shutdown := Init(context.Background(), "svc", "mc", lis.Addr().String())
+	ctx, span := tracer.Start(context.Background(), "test")
+	span.End()
+	if err := shutdown(ctx); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+
+	otlp.mu.Lock()
+	received := len(otlp.requests)
+	otlp.mu.Unlock()
+	if received == 0 {
+		t.Errorf("no spans received")
+	}
+}


### PR DESCRIPTION
## Summary
- enable dependency injection for executing sling and calling runSlingOnce
- add unit tests for config loading and pipeline detection
- add unit tests for wrapper tracing and noop behaviour
- add unit tests for OTEL tracer initialization

## Testing
- `go test ./...`

## Details

- Added an injectable command creator in sling.go to make execution testable
- Introduced a replaceable runSlingOnceFunc in main.go for easier mocking during tests
- Created a noop pipeline test verifying that the wrapper logs correctly and doesn’t invoke the real runner
- Implemented a sling execution test that feeds fake log lines through a generated shell script to assert OTEL events
- Added configuration and tracing initialization tests covering default values and OTLP server interaction

------
https://chatgpt.com/codex/tasks/task_e_68888641a6c883239d4d78f8a90fbffe