### PR TITLE
feat(codex): Allow configurable Sling binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ This will deploy:
 - `SYNC_MAX_RETRIES` → number of retries (default 3).
 - `SYNC_BACKOFF_BASE` → backoff base (default 5s).
 - `OTEL_EXPORTER_OTLP_ENDPOINT` → OTel Collector endpoint (default otel-collector:4317).
+- `SLING_BIN` → path to the Sling CLI binary (default `sling`).
 
 ## Grafana Dashboard
 

--- a/cmd/wrapper/main.go
+++ b/cmd/wrapper/main.go
@@ -68,7 +68,7 @@ func runPipeline(ctx context.Context, tracer trace.Tracer, cfg config.Config, pi
 	var lastErr error
 	var rowsSynced int
 	for attempt := 1; attempt <= cfg.MaxRetries; attempt++ {
-		rows, err := runSlingOnceFunc(ctx, pipeline, cfg.StateLocation, jobID, span)
+		rows, err := runSlingOnceFunc(ctx, cfg.SlingBinary, pipeline, cfg.StateLocation, jobID, span)
 		rowsSynced += rows
 		if err == nil {
 			lastErr = nil

--- a/cmd/wrapper/pipeline_test.go
+++ b/cmd/wrapper/pipeline_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestRunPipelineNoop(t *testing.T) {
 	var called bool
-	runSlingOnceFunc = func(ctx context.Context, pipeline, state, jobID string, span trace.Span) (int, error) {
+	runSlingOnceFunc = func(ctx context.Context, bin, pipeline, state, jobID string, span trace.Span) (int, error) {
 		called = true
 		return 0, nil
 	}

--- a/cmd/wrapper/sling.go
+++ b/cmd/wrapper/sling.go
@@ -22,8 +22,8 @@ type SlingLogLine struct {
 	Error   string `json:"error,omitempty"`
 }
 
-func runSlingOnce(ctx context.Context, pipeline, stateLocation, jobID string, span trace.Span) (int, error) {
-	cmd := execCommandContext(ctx, "sling", "sync", "--config", pipeline, "--log-format", "json")
+func runSlingOnce(ctx context.Context, slingBin, pipeline, stateLocation, jobID string, span trace.Span) (int, error) {
+	cmd := execCommandContext(ctx, slingBin, "sync", "--config", pipeline, "--log-format", "json")
 	cmd.Env = append(os.Environ(), fmt.Sprintf("SLING_STATE=%s", stateLocation))
 
 	stdout, err := cmd.StdoutPipe()

--- a/cmd/wrapper/sling_test.go
+++ b/cmd/wrapper/sling_test.go
@@ -44,7 +44,7 @@ func TestRunSlingOnceEvents(t *testing.T) {
 
 	ctx := context.Background()
 	ctx, span := tracer.Start(ctx, "run")
-	rows, err := runSlingOnce(ctx, "pipe.yaml", "state", "job", span)
+	rows, err := runSlingOnce(ctx, script, "pipe.yaml", "state", "job", span)
 	span.End()
 	if err != nil {
 		t.Fatalf("runSlingOnce error: %v", err)

--- a/cmd/wrapper/sqlite_duckdb_test.go
+++ b/cmd/wrapper/sqlite_duckdb_test.go
@@ -62,7 +62,7 @@ func TestSQLiteToDuckDBSync(t *testing.T) {
 
 	cfg := config.Config{MissionClusterID: "mc", StateLocation: filepath.Join(tmp, "state"), SyncMode: "normal", MaxRetries: 1, BackoffBase: time.Millisecond}
 
-	runSlingOnceFunc = func(ctx context.Context, pipeline, state, jobID string, span trace.Span) (int, error) {
+	runSlingOnceFunc = func(ctx context.Context, bin, pipeline, state, jobID string, span trace.Span) (int, error) {
 		src, err := sql.Open("sqlite3", missionPath)
 		if err != nil {
 			return 0, err
@@ -188,7 +188,7 @@ func TestSQLiteTwoMissionDBsToDuckDB(t *testing.T) {
 
 	var srcPath string
 	var currentMission string
-	runSlingOnceFunc = func(ctx context.Context, pipeline, state, jobID string, span trace.Span) (int, error) {
+	runSlingOnceFunc = func(ctx context.Context, bin, pipeline, state, jobID string, span trace.Span) (int, error) {
 		src, err := sql.Open("sqlite3", srcPath)
 		if err != nil {
 			return 0, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	SyncMode         string
 	MaxRetries       int
 	BackoffBase      time.Duration
+	SlingBinary      string
 }
 
 // FromEnv constructs a Config from environment variables.
@@ -30,6 +31,7 @@ func FromEnv() Config {
 		SyncMode:         getEnv("SYNC_MODE", "normal"),
 		MaxRetries:       getEnvInt("SYNC_MAX_RETRIES", 3),
 		BackoffBase:      getEnvDuration("SYNC_BACKOFF_BASE", 5*time.Second),
+		SlingBinary:      getEnv("SLING_BIN", "sling"),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,6 +28,9 @@ func TestFromEnvDefaults(t *testing.T) {
 	if cfg.BackoffBase != 5*time.Second {
 		t.Errorf("unexpected default backoff: %s", cfg.BackoffBase)
 	}
+	if cfg.SlingBinary != "sling" {
+		t.Errorf("unexpected default sling binary: %s", cfg.SlingBinary)
+	}
 }
 
 func TestFromEnvOverrides(t *testing.T) {
@@ -38,6 +41,7 @@ func TestFromEnvOverrides(t *testing.T) {
 	t.Setenv("SYNC_MODE", "backfill")
 	t.Setenv("SYNC_MAX_RETRIES", "5")
 	t.Setenv("SYNC_BACKOFF_BASE", "2s")
+	t.Setenv("SLING_BIN", "/usr/local/bin/sling")
 
 	cfg := FromEnv()
 	if cfg.MissionClusterID != "mc1" || cfg.PipelineFile != "pipeline.yaml" {
@@ -51,6 +55,9 @@ func TestFromEnvOverrides(t *testing.T) {
 	}
 	if cfg.OTELEndpoint != "otel:4317" {
 		t.Errorf("unexpected otel endpoint: %s", cfg.OTELEndpoint)
+	}
+	if cfg.SlingBinary != "/usr/local/bin/sling" {
+		t.Errorf("unexpected sling binary: %s", cfg.SlingBinary)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make Sling binary path configurable via `SLING_BIN`
- pass binary path to sling invocation
- document new env var

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6889ef9f4794832397d6a9ed16ec6f86