### PR TITLE
fix: Use strconv for int env parsing and add tests

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 )
 
@@ -61,9 +62,9 @@ func getEnv(key, fallback string) string {
 
 func getEnvInt(key string, fallback int) int {
 	if v := os.Getenv(key); v != "" {
-		var i int
-		fmt.Sscanf(v, "%d", &i)
-		return i
+		if i, err := strconv.Atoi(v); err == nil {
+			return i
+		}
 	}
 	return fallback
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -94,3 +94,22 @@ func TestPipelinesMissing(t *testing.T) {
 		t.Fatalf("expected error for missing config")
 	}
 }
+
+func TestGetEnvInt(t *testing.T) {
+	const key = "TEST_ENV_INT"
+
+	os.Unsetenv(key)
+	if got := getEnvInt(key, 42); got != 42 {
+		t.Fatalf("expected fallback 42, got %d", got)
+	}
+
+	t.Setenv(key, "7")
+	if got := getEnvInt(key, 42); got != 7 {
+		t.Fatalf("expected 7, got %d", got)
+	}
+
+	t.Setenv(key, "notanint")
+	if got := getEnvInt(key, 42); got != 42 {
+		t.Fatalf("expected fallback 42 on invalid int, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary
- use `strconv.Atoi` in `getEnvInt` to validate and parse integer env vars
- add unit tests for `getEnvInt` to cover valid, missing, and invalid values

## Testing
- `go vet ./...`
- `make test`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_688de10174b483239e73cb2d50b33bec