### PR TITLE
fix: implement exponential backoff

### DIFF
--- a/cmd/wrapper/backoff_test.go
+++ b/cmd/wrapper/backoff_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"sling-sync-wrapper/internal/config"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestRunPipelineExponentialBackoff(t *testing.T) {
+	var calls int
+	runSlingOnceFunc = func(ctx context.Context, bin, pipeline, state, jobID string, span trace.Span) (int, error) {
+		calls++
+		if calls < 4 {
+			return 0, fmt.Errorf("fail %d", calls)
+		}
+		return 0, nil
+	}
+	defer func() { runSlingOnceFunc = runSlingOnce }()
+
+	var sleeps []time.Duration
+	sleepFunc = func(d time.Duration) {
+		sleeps = append(sleeps, d)
+	}
+	defer func() { sleepFunc = time.Sleep }()
+
+	tracer := trace.NewNoopTracerProvider().Tracer("test")
+	cfg := config.Config{MissionClusterID: "mc", StateLocation: "state", SyncMode: "normal", MaxRetries: 4, BackoffBase: time.Millisecond}
+
+	runPipeline(context.Background(), tracer, cfg, "pipe.yaml", "job1")
+
+	expected := []time.Duration{cfg.BackoffBase, 2 * cfg.BackoffBase, 4 * cfg.BackoffBase}
+	if len(sleeps) != len(expected) {
+		t.Fatalf("expected %d sleeps, got %d", len(expected), len(sleeps))
+	}
+	for i, d := range expected {
+		if sleeps[i] != d {
+			t.Fatalf("sleep %d = %v, want %v", i, sleeps[i], d)
+		}
+	}
+}

--- a/cmd/wrapper/main.go
+++ b/cmd/wrapper/main.go
@@ -15,7 +15,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-var runSlingOnceFunc = runSlingOnce
+var (
+	runSlingOnceFunc = runSlingOnce
+	sleepFunc        = time.Sleep
+)
 
 func main() {
 	ctx := context.Background()
@@ -75,9 +78,9 @@ func runPipeline(ctx context.Context, tracer trace.Tracer, cfg config.Config, pi
 			break
 		}
 		lastErr = err
-		wait := time.Duration(attempt) * cfg.BackoffBase
+		wait := cfg.BackoffBase * time.Duration(1<<uint(attempt-1))
 		log.Printf("Attempt %d failed: %v, retrying in %s", attempt, err, wait)
-		time.Sleep(wait)
+		sleepFunc(wait)
 	}
 
 	duration := time.Since(startTime)


### PR DESCRIPTION
## Summary
- implement exponential backoff using powers of two for retry waits
- add tests validating exponential retry delays

## Testing
- `go vet ./...`
- `go test ./...`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_688df24ece6083239190fe1676ab2f1f