### PR TITLE
chore: add maintenance make targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,9 @@ These guidelines apply to the entire repository.
   make build
   ```
 - Additional useful commands from the Makefile:
+  - `make fmt` – format Go code.
+  - `make vet` – run static analysis.
+  - `make tidy` – tidy module dependencies.
   - `make docker` – build the container image.
   - `make push` – push the image to the registry.
   - `make run-local` – run the wrapper locally using default env vars.

--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,14 @@ run-local:
 quickstart:
 	go run ./cmd/quickstart
 
+fmt:
+	go fmt ./...
+
+vet:
+	go vet ./...
+
+tidy:
+	go mod tidy
+
 test:
 	go test ./...

--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ A pre-built Grafana dashboard is provided:
 
 ## Development
 
+### Maintenance
+
+Common development tasks are available via the Makefile:
+
+```bash
+make fmt   # format Go code
+make vet   # run go vet
+make tidy  # tidy module dependencies
+make test  # run unit tests
+```
+
 Run locally with multiple pipelines
 
 ```bash


### PR DESCRIPTION
## Summary
- add make fmt, vet and tidy commands
- document maintenance targets in README and AGENTS instructions

## Testing
- `go fmt ./...`
- `go mod tidy`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688df84ca8888323894392be2d4255db