### PR TITLE
feat: add Makefile target to install Sling CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 APP_NAME = sling-sync-wrapper
 REGISTRY = registry.local
+SLING_CLI_VERSION ?= latest
 
 all: build
 
@@ -23,6 +24,9 @@ run-local:
 
 quickstart:
 	go run ./cmd/quickstart
+
+install-sling-cli:
+	go install github.com/slingdata/sling-cli@$(SLING_CLI_VERSION)
 
 fmt:
 	go fmt ./...

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ run pipeline files, so the CLI must be installed locally.
 ### Prerequisites
 
 - Go 1.22+
-- Sling CLI installed and on your `PATH` (download from [Sling releases](https://github.com/slingdata/sling/releases) or `go install github.com/slingdata/sling-cli@latest`)
+- Sling CLI installed and on your `PATH` (run `make install-sling-cli` or download from [Sling releases](https://github.com/slingdata/sling/releases))
 - GreptimeDB and Grafana (optional for observability)
 
 ### Build


### PR DESCRIPTION
## Summary
- add `SLING_CLI_VERSION` variable and `install-sling-cli` Makefile target to fetch Sling CLI
- document Makefile target in quickstart prerequisites

## Testing
- `go fmt ./...`
- `go mod tidy`
- `go vet ./...`
- `make test`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_688e017b28d0832399e52f03c96bb885