### PR TITLE
chore: add duckdb install target and document quickstart workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,13 @@ These guidelines apply to the entire repository.
   - `make docker` – build the container image.
   - `make push` – push the image to the registry.
   - `make run-local` – run the wrapper locally using default env vars.
-  - `make quickstart` – run the quickstart example.
+  - `make install-sling-cli` – install the Sling CLI.
+  - `make install-duckdb-cli` – install the DuckDB CLI used to inspect quickstart results.
+  - `make quickstart` – run the quickstart example and verify the output:
+    ```bash
+    duckdb quickstart/command.db "select distinct synced_from from telemetry;"
+    ```
+    The result should list `mission1` and `mission2`.
 
 Ensure tests pass before opening a pull request.
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 APP_NAME = sling-sync-wrapper
 REGISTRY = registry.local
 SLING_CLI_VERSION ?= latest
+DUCKDB_CLI_VERSION ?= 0.10.1
 
 all: build
 
@@ -27,6 +28,12 @@ quickstart:
 
 install-sling-cli:
 	go install github.com/slingdata/sling-cli@$(SLING_CLI_VERSION)
+
+install-duckdb-cli:
+	curl -L https://github.com/duckdb/duckdb/releases/download/v$(DUCKDB_CLI_VERSION)/duckdb_cli-linux-amd64.zip -o /tmp/duckdb_cli.zip
+	unzip -o /tmp/duckdb_cli.zip -d /usr/local/bin
+	chmod +x /usr/local/bin/duckdb
+	rm /tmp/duckdb_cli.zip
 
 fmt:
 	go fmt ./...


### PR DESCRIPTION
## Summary
- add make target to install the DuckDB CLI
- document CLI installation and quickstart verification steps in `AGENTS.md`

## Testing
- `make install-sling-cli` *(fails: could not read username for https://github.com)*
- `make install-duckdb-cli`
- `duckdb --version`
- `make -B quickstart`
- `duckdb quickstart/command.db "select synced_from, count(*) as cnt from telemetry group by synced_from;"`
- `go fmt ./...`
- `go mod tidy`
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688e1f9a086c83238b90d237a9dea331