### PR TITLE
chore: automate quickstart dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,10 @@ These guidelines apply to the entire repository.
   ```bash
   make build
   ```
+- Run the quickstart example to verify everything works end-to-end:
+  ```bash
+  make quickstart
+  ```
 - Additional useful commands from the Makefile:
   - `make fmt` – format Go code.
   - `make vet` – run static analysis.
@@ -35,11 +39,7 @@ These guidelines apply to the entire repository.
   - `make run-local` – run the wrapper locally using default env vars.
   - `make install-sling-cli` – install the Sling CLI.
   - `make install-duckdb-cli` – install the DuckDB CLI used to inspect quickstart results.
-  - `make quickstart` – run the quickstart example and verify the output:
-    ```bash
-    duckdb quickstart/command.db "select distinct synced_from from telemetry;"
-    ```
-    The result should list `mission1` and `mission2`.
+  - `make quickstart` – install dependencies, run the quickstart, and print distinct `synced_from` missions (`mission1` and `mission2`).
 
 Ensure tests pass before opening a pull request.
 

--- a/Makefile
+++ b/Makefile
@@ -23,25 +23,34 @@ run-local:
 	./bin/$(APP_NAME)
 
 
-quickstart:
+quickstart: install-sling-cli install-duckdb-cli
 	go run ./cmd/quickstart
+	duckdb quickstart/command.db "select distinct synced_from from telemetry;"
 
 install-sling-cli:
-	if [ "$(SLING_CLI_VERSION)" = "latest" ]; then \
-	URL="https://github.com/slingdata-io/sling-cli/releases/latest/download/sling_linux_amd64.tar.gz"; \
+	@if ! command -v sling >/dev/null 2>&1; then \
+	        if [ "$(SLING_CLI_VERSION)" = "latest" ]; then \
+	                URL="https://github.com/slingdata-io/sling-cli/releases/latest/download/sling_linux_amd64.tar.gz"; \
+	        else \
+	                URL="https://github.com/slingdata-io/sling-cli/releases/download/$(SLING_CLI_VERSION)/sling_linux_amd64.tar.gz"; \
+	        fi; \
+	        curl -L $$URL -o /tmp/sling_cli.tar.gz; \
+	        tar -C /usr/local/bin -xzf /tmp/sling_cli.tar.gz sling; \
+	        chmod +x /usr/local/bin/sling; \
+	        rm /tmp/sling_cli.tar.gz; \
 	else \
-	URL="https://github.com/slingdata-io/sling-cli/releases/download/$(SLING_CLI_VERSION)/sling_linux_amd64.tar.gz"; \
-	fi; \
-	curl -L $$URL -o /tmp/sling_cli.tar.gz; \
-	tar -C /usr/local/bin -xzf /tmp/sling_cli.tar.gz sling; \
-	chmod +x /usr/local/bin/sling; \
-	rm /tmp/sling_cli.tar.gz
+	        echo "sling already installed"; \
+	fi
 
 install-duckdb-cli:
-	curl -L https://github.com/duckdb/duckdb/releases/download/v$(DUCKDB_CLI_VERSION)/duckdb_cli-linux-amd64.zip -o /tmp/duckdb_cli.zip
-	unzip -o /tmp/duckdb_cli.zip -d /usr/local/bin
-	chmod +x /usr/local/bin/duckdb
-	rm /tmp/duckdb_cli.zip
+	@if ! command -v duckdb >/dev/null 2>&1; then \
+	        curl -L https://github.com/duckdb/duckdb/releases/download/v$(DUCKDB_CLI_VERSION)/duckdb_cli-linux-amd64.zip -o /tmp/duckdb_cli.zip; \
+	        unzip -o /tmp/duckdb_cli.zip -d /usr/local/bin; \
+	        chmod +x /usr/local/bin/duckdb; \
+	        rm /tmp/duckdb_cli.zip; \
+	else \
+	        echo "duckdb already installed"; \
+	fi
 
 fmt:
 	go fmt ./...


### PR DESCRIPTION
## Summary
- ensure `make quickstart` installs Sling and DuckDB CLIs if missing and runs a validation query
- document quickstart verification in AGENTS instructions

## Testing
- `go fmt ./...`
- `go mod tidy`
- `go vet ./...`
- `make test`
- `make quickstart`


------
https://chatgpt.com/codex/tasks/task_e_688e304853708323b96a5a50932203d4