### PR TITLE
fix: upgrade Dockerfile Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build stage
-FROM golang:1.22 as builder
+# Build stage uses Go 1.24 to match go.mod
+FROM golang:1.24 as builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
## Summary
- align build image with Go 1.24 used in go.mod

## Testing
- `go fmt ./...`
- `go mod tidy`
- `go vet ./...`
- `make test`
- `make build`
- `make quickstart`


------
https://chatgpt.com/codex/tasks/task_e_688e4745f8548323a163fc94d391312b