### PR TITLE
fix: avoid global env mutation in wrapper

### DIFF
--- a/cmd/wrapper/main.go
+++ b/cmd/wrapper/main.go
@@ -36,8 +36,6 @@ func main() {
 	var failed bool
 	for _, pipeline := range pipelines {
 		jobID := uuid.NewString()
-		os.Setenv("SYNC_JOB_ID", jobID)
-		os.Setenv("SLING_CONFIG", pipeline)
 		if err := runPipeline(ctx, tracer, cfg, pipeline, jobID); err != nil {
 			failed = true
 		}

--- a/cmd/wrapper/sling.go
+++ b/cmd/wrapper/sling.go
@@ -26,7 +26,11 @@ const maxScanTokenSize = 1024 * 1024 // 1 MiB
 
 func runSlingOnce(ctx context.Context, slingBin, pipeline, stateLocation, jobID string, span trace.Span) (int, error) {
 	cmd := execCommandContext(ctx, slingBin, "sync", "--config", pipeline, "--log-format", "json")
-	cmd.Env = append(os.Environ(), fmt.Sprintf("SLING_STATE=%s", stateLocation))
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("SLING_STATE=%s", stateLocation),
+		fmt.Sprintf("SYNC_JOB_ID=%s", jobID),
+		fmt.Sprintf("SLING_CONFIG=%s", pipeline),
+	)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
## Summary
- stop main loop from mutating SYNC_JOB_ID and SLING_CONFIG
- pass per-run env to sling process and test it

## Testing
- `go vet ./...`
- `make test`
- `make build`
- `make quickstart`


------
https://chatgpt.com/codex/tasks/task_e_688e478db4fc8323b0d3041f809fd4cb