### PR TITLE
feat: make sling timeout configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,11 @@ push: docker
 run-local:
 	MISSION_CLUSTER_ID=local \
 	SYNC_JOB_ID=$$(uuidgen) \
-	SLING_CONFIG=./pipeline.yaml \
-	SLING_STATE=file://./sling_state.json \
-	OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 \
-	./bin/$(APP_NAME)
+        SLING_CONFIG=./pipeline.yaml \
+        SLING_STATE=file://./sling_state.json \
+       SLING_TIMEOUT=30m \
+        OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 \
+        ./bin/$(APP_NAME)
 
 
 quickstart: install-sling-cli install-duckdb-cli

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The collected telemetry is stored in GreptimeDB and visualized via Grafana.
 
     - sync_job_id, rows_synced, duration_seconds, and status.
     - Logs captured as span events.
-    - Retry Logic; Retries failed syncs using exponential backoff (SYNC_MAX_RETRIES, SYNC_BACKOFF_BASE).
+    - Retry Logic; Retries failed syncs using exponential backoff (SYNC_MAX_RETRIES, SYNC_BACKOFF_BASE). Configurable Sling CLI timeout (SLING_TIMEOUT).
 
 **Multi-Pipeline Support**
 
@@ -94,6 +94,7 @@ go build -o sling-sync-wrapper ./cmd/wrapper
 MISSION_CLUSTER_ID=mission-01 \
 SLING_CONFIG=./pipeline.yaml \
 SLING_STATE=file://./sling_state.json \
+SLING_TIMEOUT=30m \
 OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 \
 ./sling-sync-wrapper
 ```
@@ -128,6 +129,7 @@ The wrapper is configured using the following environment variables:
 | `SYNC_MAX_RETRIES` | `3` | No | Number of times to retry a failed pipeline run. |
 | `SYNC_BACKOFF_BASE` | `5s` | No | Base duration for exponential backoff between retries. |
 | `SLING_BIN` | `sling` | No | Path to the Sling CLI binary. |
+| `SLING_TIMEOUT` | `30m` | No | Maximum duration for a single Sling CLI invocation. |
 
 `*` Either `SLING_CONFIG` or `PIPELINE_DIR` must be set.
 

--- a/cmd/wrapper/main.go
+++ b/cmd/wrapper/main.go
@@ -63,6 +63,8 @@ func runPipeline(ctx context.Context, tracer trace.Tracer, cfg config.Config, pi
 
 	startTime := time.Now()
 
+	slingCLITimeout = cfg.SlingTimeout
+
 	if cfg.SyncMode == "noop" {
 		log.Printf("[NOOP] Would run Sling pipeline %s", pipeline)
 		span.SetAttributes(attribute.String("status", "noop"))

--- a/cmd/wrapper/sling.go
+++ b/cmd/wrapper/sling.go
@@ -26,8 +26,9 @@ type SlingLogLine struct {
 
 const (
 	maxScanTokenSize = 1024 * 1024 // 1 MiB
-	slingCLITimeout  = 30 * time.Minute
 )
+
+var slingCLITimeout = 30 * time.Minute
 
 func runSlingOnce(ctx context.Context, slingBin, pipeline, stateLocation, jobID string, span trace.Span) (int, error) {
 	ctx, cancel := context.WithTimeout(ctx, slingCLITimeout)

--- a/helm/sling-sync-wrapper/templates/cronjob.yaml
+++ b/helm/sling-sync-wrapper/templates/cronjob.yaml
@@ -36,6 +36,8 @@ spec:
               value: {{ .Values.syncMaxRetries | quote }}
             - name: SYNC_BACKOFF_BASE
               value: {{ .Values.syncBackoffBase | quote }}
+            - name: SLING_TIMEOUT
+              value: {{ .Values.slingTimeout | quote }}
             volumeMounts:
             - name: sling-pipelines
               mountPath: {{ .Values.pipelineDir | quote }}

--- a/helm/sling-sync-wrapper/values.yaml
+++ b/helm/sling-sync-wrapper/values.yaml
@@ -17,4 +17,5 @@ otelExporterEndpoint: "otel-collector:4317"
 syncMode: "normal"
 syncMaxRetries: 3
 syncBackoffBase: "5s"
+slingTimeout: "30m"
 schedule: "*/5 * * * *"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	MaxRetries       int
 	BackoffBase      time.Duration
 	SlingBinary      string
+	SlingTimeout     time.Duration
 }
 
 // FromEnv constructs a Config from environment variables.
@@ -33,6 +34,7 @@ func FromEnv() Config {
 		MaxRetries:       getEnvInt("SYNC_MAX_RETRIES", 3),
 		BackoffBase:      getEnvDuration("SYNC_BACKOFF_BASE", 5*time.Second),
 		SlingBinary:      getEnv("SLING_BIN", "sling"),
+		SlingTimeout:     getEnvDuration("SLING_TIMEOUT", 30*time.Minute),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,6 +31,9 @@ func TestFromEnvDefaults(t *testing.T) {
 	if cfg.SlingBinary != "sling" {
 		t.Errorf("unexpected default sling binary: %s", cfg.SlingBinary)
 	}
+	if cfg.SlingTimeout != 30*time.Minute {
+		t.Errorf("unexpected default sling timeout: %s", cfg.SlingTimeout)
+	}
 }
 
 func TestFromEnvOverrides(t *testing.T) {
@@ -42,6 +45,7 @@ func TestFromEnvOverrides(t *testing.T) {
 	t.Setenv("SYNC_MAX_RETRIES", "5")
 	t.Setenv("SYNC_BACKOFF_BASE", "2s")
 	t.Setenv("SLING_BIN", "/usr/local/bin/sling")
+	t.Setenv("SLING_TIMEOUT", "10s")
 
 	cfg := FromEnv()
 	if cfg.MissionClusterID != "mc1" || cfg.PipelineFile != "pipeline.yaml" {
@@ -58,6 +62,9 @@ func TestFromEnvOverrides(t *testing.T) {
 	}
 	if cfg.SlingBinary != "/usr/local/bin/sling" {
 		t.Errorf("unexpected sling binary: %s", cfg.SlingBinary)
+	}
+	if cfg.SlingTimeout != 10*time.Second {
+		t.Errorf("unexpected sling timeout: %s", cfg.SlingTimeout)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `SLING_TIMEOUT` env var and config field to control Sling CLI runtime
- wire configuration through wrapper and helm charts
- document timeout usage and default

## Testing
- `go mod tidy`
- `go vet -v ./cmd/wrapper ./internal/...` *(failed: undefined: Conn)*
- `make test` *(interrupted: build of sqlite3 dependencies)*
- `make build`
- `make quickstart` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688e5c0ee8f48323a9e12507600a8e2a