### PR TITLE
fix(config): sort and validate pipeline files

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"time"
 )
@@ -49,9 +50,11 @@ func Pipelines(cfg Config) ([]string, error) {
 		pipelines = append(pipelines, files...)
 	} else if cfg.PipelineFile != "" {
 		pipelines = append(pipelines, cfg.PipelineFile)
-	} else {
-		return nil, fmt.Errorf("no SLING_CONFIG or PIPELINE_DIR specified")
 	}
+	if len(pipelines) == 0 {
+		return nil, fmt.Errorf("no pipeline files found (set SLING_CONFIG or PIPELINE_DIR)")
+	}
+	sort.Strings(pipelines)
 	return pipelines, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -90,8 +91,9 @@ func TestPipelinesDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(files) != 2 {
-		t.Fatalf("expected 2 files, got %v", files)
+	expected := []string{f1, f2}
+	if !reflect.DeepEqual(files, expected) {
+		t.Fatalf("expected %v, got %v", expected, files)
 	}
 }
 
@@ -99,6 +101,14 @@ func TestPipelinesMissing(t *testing.T) {
 	_, err := Pipelines(Config{})
 	if err == nil {
 		t.Fatalf("expected error for missing config")
+	}
+}
+
+func TestPipelinesEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	_, err := Pipelines(Config{PipelineDir: dir})
+	if err == nil {
+		t.Fatalf("expected error for empty pipeline dir")
 	}
 }
 


### PR DESCRIPTION
## Summary
- sort collected pipeline configs for deterministic runs
- error when no pipelines found to avoid silent misconfigurations
- test pipeline ordering and empty directory handling

## Testing
- `go vet ./...` *(failed: command hung and was interrupted)*
- `make test` *(failed: command hung and was interrupted)*
- `go test ./internal/config`
- `make build`
- `make quickstart` *(failed: command hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688e5f4ac538832396d0d65b0e7f8030