### PR TITLE
docs: add developer quickstart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,17 @@ A pre-built Grafana dashboard is provided:
   - `YOUR_TRACE_DATASOURCE_UID` → GreptimeDB traces.
   - `YOUR_LOGS_DATASOURCE_UID` → GreptimeDB logs.
 
+## Developer Quickstart
+
+Run the core checks and build the Docker image with:
+
+```bash
+make fmt    # format Go code
+make vet    # run static analysis
+make test   # run unit tests
+make docker # build the Docker image
+```
+
 ## Development
 
 ### Maintenance


### PR DESCRIPTION
## Summary
- add developer quickstart section with common make targets

## Testing
- `go fmt ./...`
- `go mod tidy`
- `go vet ./...`
- `make test` *(fails: context deadline exceeded)*
- `make build`
- `make quickstart`
- `make docker` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688e61ac61488323b50baa77509db9a3