### PR TITLE
chore: add check target for code quality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,9 @@ tidy:
 
 test:
 	go test ./...
+
+check:
+	$(MAKE) fmt
+	$(MAKE) vet
+	$(MAKE) tidy
+	$(MAKE) test

--- a/README.md
+++ b/README.md
@@ -174,9 +174,7 @@ A pre-built Grafana dashboard is provided:
 Run the core checks and build the Docker image with:
 
 ```bash
-make fmt    # format Go code
-make vet    # run static analysis
-make test   # run unit tests
+make check  # run fmt, vet, tidy, and test
 make docker # build the Docker image
 ```
 
@@ -187,6 +185,7 @@ make docker # build the Docker image
 Common development tasks are available via the Makefile:
 
 ```bash
+make check # run fmt, vet, tidy, and unit tests
 make fmt   # format Go code
 make vet   # run go vet
 make tidy  # tidy module dependencies

--- a/cmd/wrapper/main.go
+++ b/cmd/wrapper/main.go
@@ -63,7 +63,9 @@ func runPipeline(ctx context.Context, tracer trace.Tracer, cfg config.Config, pi
 
 	startTime := time.Now()
 
+	prevTimeout := slingCLITimeout
 	slingCLITimeout = cfg.SlingTimeout
+	defer func() { slingCLITimeout = prevTimeout }()
 
 	if cfg.SyncMode == "noop" {
 		log.Printf("[NOOP] Would run Sling pipeline %s", pipeline)


### PR DESCRIPTION
## Summary
- add `check` target to run fmt, vet, tidy, and tests together
- document consolidated `make check` workflow in README
- restore Sling CLI timeout after pipeline runs to keep subsequent checks stable

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_688e639bf41483238a26b43d3b450bd7