### PR TITLE
test: ensure CLI respects env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ go build -o sling-sync-wrapper ./cmd/wrapper
   --otel-endpoint localhost:4317
 ```
 
+You can also rely solely on environment variables, which is helpful in Kubernetes deployments:
+
+```bash
+MISSION_CLUSTER_ID=mission-01 \
+SLING_CONFIG=./pipeline.yaml \
+SLING_STATE=file://./sling_state.json \
+OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 \
+./sling-sync-wrapper run
+```
+
 Flags override environment variables, which remain available for compatibility.
 The wrapper automatically generates a unique `SYNC_JOB_ID` for each run.
 

--- a/cmd/wrapper/cli_env_test.go
+++ b/cmd/wrapper/cli_env_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestNewRootCmdEnv verifies that environment variables are used as defaults for CLI flags.
+func TestNewRootCmdEnv(t *testing.T) {
+	t.Setenv("MISSION_CLUSTER_ID", "env-mission")
+	t.Setenv("SLING_CONFIG", "env-pipeline.yaml")
+	t.Setenv("SLING_STATE", "env-state.json")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "otel-env:4317")
+	t.Setenv("SYNC_MAX_RETRIES", "7")
+	t.Setenv("SYNC_BACKOFF_BASE", "3s")
+	t.Setenv("SLING_BIN", "/env/sling")
+	t.Setenv("SLING_TIMEOUT", "45s")
+
+	cmd := newRootCmd()
+
+	tests := []struct {
+		flag string
+		want string
+	}{
+		{"mission-cluster-id", "env-mission"},
+		{"config", "env-pipeline.yaml"},
+		{"state", "env-state.json"},
+		{"otel-endpoint", "otel-env:4317"},
+		{"max-retries", "7"},
+		{"backoff-base", "3s"},
+		{"sling-binary", "/env/sling"},
+		{"sling-timeout", "45s"},
+	}
+
+	for _, tt := range tests {
+		got := cmd.PersistentFlags().Lookup(tt.flag).Value.String()
+		if got != tt.want {
+			t.Errorf("flag %s = %s, want %s", tt.flag, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- document how to run the wrapper using environment variables, handy for Kubernetes
- add a test to confirm environment variables are used as default CLI flags

## Testing
- `go fmt ./...`
- `go mod tidy`
- `go vet ./...`
- `make test`
- `make build`
- `make quickstart`


------
https://chatgpt.com/codex/tasks/task_e_688efd044d9c8323b74876a2b500b7b0