### PR TITLE
feat(config): simplify pipeline discovery logic

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,21 +41,25 @@ func FromEnv() Config {
 
 // Pipelines returns a list of pipeline files to run.
 func Pipelines(cfg Config) ([]string, error) {
-	var pipelines []string
-	if cfg.PipelineDir != "" {
+	if cfg.PipelineDir != "" && cfg.PipelineFile != "" {
+		return nil, fmt.Errorf("cannot set both PipelineDir and PipelineFile")
+	}
+
+	switch {
+	case cfg.PipelineDir != "":
 		files, err := filepath.Glob(filepath.Join(cfg.PipelineDir, "*.yaml"))
 		if err != nil {
 			return nil, err
 		}
-		pipelines = append(pipelines, files...)
-	} else if cfg.PipelineFile != "" {
-		pipelines = append(pipelines, cfg.PipelineFile)
+		sort.Strings(files)
+		if len(files) > 0 {
+			return files, nil
+		}
+	case cfg.PipelineFile != "":
+		return []string{cfg.PipelineFile}, nil
 	}
-	if len(pipelines) == 0 {
-		return nil, fmt.Errorf("no pipeline files found (set SLING_CONFIG or PIPELINE_DIR)")
-	}
-	sort.Strings(pipelines)
-	return pipelines, nil
+
+	return nil, fmt.Errorf("no pipeline files found (set SLING_CONFIG or PIPELINE_DIR)")
 }
 
 func getEnv(key, fallback string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -97,6 +97,14 @@ func TestPipelinesDir(t *testing.T) {
 	}
 }
 
+func TestPipelinesBothSet(t *testing.T) {
+	dir := t.TempDir()
+	_, err := Pipelines(Config{PipelineDir: dir, PipelineFile: "p.yaml"})
+	if err == nil {
+		t.Fatalf("expected error when both PipelineDir and PipelineFile are set")
+	}
+}
+
 func TestPipelinesMissing(t *testing.T) {
 	_, err := Pipelines(Config{})
 	if err == nil {


### PR DESCRIPTION
## Summary
- streamline pipeline discovery by switching on file/dir inputs and validating conflicting values
- add test coverage for conflicting pipeline settings

## Testing
- `go vet ./...`
- `go test ./...`
- `make build`
- `make quickstart`


------
https://chatgpt.com/codex/tasks/task_e_688f080354b0832397988f064b514f5d