### PR TITLE
refactor: wrap errors to preserve context

### DIFF
--- a/cmd/wrapper/state.go
+++ b/cmd/wrapper/state.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/url"
 	"os"
@@ -14,7 +15,7 @@ func resetState(cfg config.Config) error {
 	u, err := url.Parse(cfg.StateLocation)
 	if err != nil {
 		log.Printf("Invalid state location: %v", err)
-		return err
+		return fmt.Errorf("parse state location: %w", err)
 	}
 	if u.Scheme != "" && u.Scheme != "file" {
 		log.Printf("State location scheme %q is not supported for backfill", u.Scheme)
@@ -31,7 +32,7 @@ func resetState(cfg config.Config) error {
 	}
 	if err := removeAllFunc(p); err != nil {
 		log.Printf("Failed to reset state: %v", err)
-		return err
+		return fmt.Errorf("remove state path %s: %w", p, err)
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,7 +49,7 @@ func Pipelines(cfg Config) ([]string, error) {
 	case cfg.PipelineDir != "":
 		files, err := filepath.Glob(filepath.Join(cfg.PipelineDir, "*.yaml"))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("find pipeline files: %w", err)
 		}
 		sort.Strings(files)
 		if len(files) > 0 {


### PR DESCRIPTION
## Summary
- wrap errors with fmt.Errorf("...: %w", err) to retain context in config, sampledb, and wrapper packages
- ensure pipeline execution and state reset errors surface details for easier debugging

## Testing
- `go vet ./...`
- `make test`
- `make build`
- `make quickstart`


------
https://chatgpt.com/codex/tasks/task_e_688f11f1ca24832392ddd13791778797