### PR TITLE
feat: add structured logging with context

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This project wraps the Sling CLI to:
 
 - Run data sync jobs from mission clusters to a central command cluster.
 - Emit OpenTelemetry traces and logs for rich observability.
+- Output structured JSON logs for context-aware debugging.
 - Support multiple pipelines, retry logic, backfill mode, and noop (dry-run) mode.
 - Integrate easily into Kubernetes as a CronJob.
 

--- a/cmd/quickstart/main.go
+++ b/cmd/quickstart/main.go
@@ -6,17 +6,20 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 
+	"sling-sync-wrapper/internal/logging"
 	"sling-sync-wrapper/internal/sampledb"
 )
 
 func main() {
+	logger := logging.New()
+
 	dir := "quickstart"
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		log.Fatal(err)
+		logger.Error("create quickstart dir", "err", err)
+		os.Exit(1)
 	}
 
 	mission1 := filepath.Join(dir, "mission1.db")
@@ -24,25 +27,31 @@ func main() {
 	command := filepath.Join(dir, "command.db")
 
 	if err := sampledb.CreateMissionDB(mission1, "mission1", 10); err != nil {
-		log.Fatalf("setup mission1: %v", err)
+		logger.Error("setup mission1", "err", err)
+		os.Exit(1)
 	}
 	if err := sampledb.CreateMissionDB(mission2, "mission2", 10); err != nil {
-		log.Fatalf("setup mission2: %v", err)
+		logger.Error("setup mission2", "err", err)
+		os.Exit(1)
 	}
 	if err := sampledb.EnsureCommandTable(command, true); err != nil {
-		log.Fatalf("setup command db: %v", err)
+		logger.Error("setup command db", "err", err)
+		os.Exit(1)
 	}
 
 	if _, err := sampledb.Sync(mission1, command, "mission1", true); err != nil {
-		log.Fatal(err)
+		logger.Error("sync mission1", "err", err)
+		os.Exit(1)
 	}
 	if _, err := sampledb.Sync(mission2, command, "mission2", true); err != nil {
-		log.Fatal(err)
+		logger.Error("sync mission2", "err", err)
+		os.Exit(1)
 	}
 
 	cnt, err := sampledb.CountRows(command)
 	if err != nil {
-		log.Fatal(err)
+		logger.Error("count rows", "err", err)
+		os.Exit(1)
 	}
 	fmt.Printf("Quickstart complete! %d rows synced into %s\n", cnt, command)
 }

--- a/cmd/wrapper/backoff_test.go
+++ b/cmd/wrapper/backoff_test.go
@@ -31,7 +31,7 @@ func TestRunPipelineExponentialBackoff(t *testing.T) {
 	tracer := trace.NewNoopTracerProvider().Tracer("test")
 	cfg := config.Config{MissionClusterID: "mc", StateLocation: "state", SyncMode: "normal", MaxRetries: 4, BackoffBase: time.Millisecond}
 
-	if err := runPipeline(context.Background(), tracer, cfg, "pipe.yaml", "job1"); err != nil {
+	if err := runPipeline(testContext(), tracer, cfg, "pipe.yaml", "job1"); err != nil {
 		t.Fatalf("runPipeline returned error: %v", err)
 	}
 

--- a/cmd/wrapper/sling.go
+++ b/cmd/wrapper/sling.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+
+	"sling-sync-wrapper/internal/logging"
 )
 
 var execCommandContext = exec.CommandContext
@@ -95,10 +96,11 @@ func runSlingOnce(ctx context.Context, slingBin, pipeline, stateLocation, jobID 
 	buf := make([]byte, 0, maxScanTokenSize)
 	scanner.Buffer(buf, maxScanTokenSize)
 	rowsSynced := 0
+	logger := logging.FromContext(ctx)
 	for scanner.Scan() {
 		rows, err := processLogLine(scanner.Text(), span)
 		if err != nil {
-			log.Printf("failed to parse Sling log line: %v", err)
+			logger.Error("failed to parse Sling log line", "err", err)
 			continue
 		}
 		if rows > 0 {

--- a/cmd/wrapper/sling_test.go
+++ b/cmd/wrapper/sling_test.go
@@ -46,7 +46,7 @@ func TestRunSlingOnceEvents(t *testing.T) {
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
 	tracer := tp.Tracer("test")
 
-	ctx := context.Background()
+	ctx := testContext()
 	ctx, span := tracer.Start(ctx, "run")
 	rows, err := runSlingOnce(ctx, script, "pipe.yaml", "state", "job", span)
 	span.End()
@@ -81,7 +81,7 @@ func TestRunSlingOnceLongLogLine(t *testing.T) {
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
 	tracer := tp.Tracer("test")
 
-	ctx := context.Background()
+	ctx := testContext()
 	ctx, span := tracer.Start(ctx, "run")
 	if _, err := runSlingOnce(ctx, script, "pipe.yaml", "state", "job", span); err != nil {
 		t.Fatalf("runSlingOnce error: %v", err)
@@ -119,7 +119,7 @@ func TestRunSlingOnceEnvironmentVariables(t *testing.T) {
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
 	tracer := tp.Tracer("test")
 
-	ctx := context.Background()
+	ctx := testContext()
 	ctx, span := tracer.Start(ctx, "run")
 	if _, err := runSlingOnce(ctx, script, "pipe.yaml", "state", "job", span); err != nil {
 		t.Fatalf("runSlingOnce error: %v", err)
@@ -164,7 +164,7 @@ func TestRunSlingOnceInvalidJSON(t *testing.T) {
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
 	tracer := tp.Tracer("test")
 
-	ctx := context.Background()
+	ctx := testContext()
 	ctx, span := tracer.Start(ctx, "run")
 	if _, err := runSlingOnce(ctx, script, "pipe.yaml", "state", "job", span); err != nil {
 		t.Fatalf("runSlingOnce error: %v", err)
@@ -202,7 +202,7 @@ func TestRunSlingOnceTimeout(t *testing.T) {
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
 	tracer := tp.Tracer("test")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(testContext(), 10*time.Millisecond)
 	defer cancel()
 	ctx, span := tracer.Start(ctx, "run")
 	_, err := runSlingOnce(ctx, script, "pipe.yaml", "state", "job", span)

--- a/cmd/wrapper/sqlite_duckdb_test.go
+++ b/cmd/wrapper/sqlite_duckdb_test.go
@@ -45,7 +45,7 @@ func TestSQLiteToDuckDBSync(t *testing.T) {
 	}
 	defer func() { runSlingOnceFunc = runSlingOnce }()
 
-	if err := runPipeline(context.Background(), tracer, cfg, pipelinePath, "job1"); err != nil {
+	if err := runPipeline(testContext(), tracer, cfg, pipelinePath, "job1"); err != nil {
 		t.Fatalf("runPipeline returned error: %v", err)
 	}
 
@@ -105,12 +105,12 @@ func TestSQLiteTwoMissionDBsToDuckDB(t *testing.T) {
 
 	srcPath = mission1Path
 	currentMission = "mission1"
-	if err := runPipeline(context.Background(), tracer, cfg, pipeline1, "job1"); err != nil {
+	if err := runPipeline(testContext(), tracer, cfg, pipeline1, "job1"); err != nil {
 		t.Fatalf("runPipeline returned error: %v", err)
 	}
 	srcPath = mission2Path
 	currentMission = "mission2"
-	if err := runPipeline(context.Background(), tracer, cfg, pipeline2, "job2"); err != nil {
+	if err := runPipeline(testContext(), tracer, cfg, pipeline2, "job2"); err != nil {
 		t.Fatalf("runPipeline returned error: %v", err)
 	}
 

--- a/cmd/wrapper/state.go
+++ b/cmd/wrapper/state.go
@@ -1,24 +1,26 @@
 package main
 
 import (
+	"context"
 	"fmt"
-	"log"
 	"net/url"
 	"os"
 	"path/filepath"
 
 	"sling-sync-wrapper/internal/config"
+	"sling-sync-wrapper/internal/logging"
 )
 
-func resetState(cfg config.Config) error {
-	log.Printf("[BACKFILL] Resetting sync state at %s", cfg.StateLocation)
+func resetState(ctx context.Context, cfg config.Config) error {
+	logger := logging.FromContext(ctx)
+	logger.Info("resetting sync state", "mode", "backfill", "state_location", cfg.StateLocation)
 	u, err := url.Parse(cfg.StateLocation)
 	if err != nil {
-		log.Printf("Invalid state location: %v", err)
+		logger.Error("invalid state location", "err", err)
 		return fmt.Errorf("parse state location: %w", err)
 	}
 	if u.Scheme != "" && u.Scheme != "file" {
-		log.Printf("State location scheme %q is not supported for backfill", u.Scheme)
+		logger.Error("state location scheme not supported for backfill", "scheme", u.Scheme)
 		return nil
 	}
 	p := u.Path
@@ -27,11 +29,11 @@ func resetState(cfg config.Config) error {
 	}
 	p = filepath.Clean(p)
 	if p == "." || p == string(os.PathSeparator) {
-		log.Printf("State location path %q is unsafe; skipping reset", p)
+		logger.Error("state location path is unsafe; skipping reset", "path", p)
 		return nil
 	}
 	if err := removeAllFunc(p); err != nil {
-		log.Printf("Failed to reset state: %v", err)
+		logger.Error("failed to reset state", "err", err)
 		return fmt.Errorf("remove state path %s: %w", p, err)
 	}
 	return nil

--- a/cmd/wrapper/state_test.go
+++ b/cmd/wrapper/state_test.go
@@ -19,7 +19,7 @@ func TestResetStateRemovesFile(t *testing.T) {
 	tempDir := t.TempDir()
 	stateFile := filepath.Join(tempDir, "state.json")
 	cfg := config.Config{StateLocation: "file://" + stateFile}
-	if err := resetState(cfg); err != nil {
+	if err := resetState(testContext(), cfg); err != nil {
 		t.Fatalf("resetState returned error: %v", err)
 	}
 	if removed != stateFile {
@@ -36,7 +36,7 @@ func TestResetStateSkipsNonFileScheme(t *testing.T) {
 	defer func() { removeAllFunc = os.RemoveAll }()
 
 	cfg := config.Config{StateLocation: "s3://bucket/state.json"}
-	if err := resetState(cfg); err != nil {
+	if err := resetState(testContext(), cfg); err != nil {
 		t.Fatalf("resetState returned error: %v", err)
 	}
 	if called {

--- a/cmd/wrapper/testutil_test.go
+++ b/cmd/wrapper/testutil_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+
+	"sling-sync-wrapper/internal/logging"
+)
+
+func testContext() context.Context {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return logging.NewContext(context.Background(), logger)
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,28 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"os"
+)
+
+// New returns a JSON logger writing to stderr with source information.
+func New() *slog.Logger {
+	handler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{AddSource: true})
+	return slog.New(handler)
+}
+
+type ctxKey struct{}
+
+// NewContext returns a copy of ctx with logger attached.
+func NewContext(ctx context.Context, logger *slog.Logger) context.Context {
+	return context.WithValue(ctx, ctxKey{}, logger)
+}
+
+// FromContext retrieves a logger from ctx or returns the default logger.
+func FromContext(ctx context.Context) *slog.Logger {
+	if l, ok := ctx.Value(ctxKey{}).(*slog.Logger); ok && l != nil {
+		return l
+	}
+	return slog.Default()
+}

--- a/internal/tracing/tracer.go
+++ b/internal/tracing/tracer.go
@@ -2,7 +2,7 @@ package tracing
 
 import (
 	"context"
-	"log"
+	"os"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -11,6 +11,8 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
+
+	"sling-sync-wrapper/internal/logging"
 )
 
 // Init sets up an OTEL tracer and returns it along with a shutdown function.
@@ -19,7 +21,8 @@ func Init(ctx context.Context, serviceName, missionClusterID, endpoint string) (
 		otlptracegrpc.WithInsecure(),
 		otlptracegrpc.WithEndpoint(endpoint))
 	if err != nil {
-		log.Fatalf("failed to create OTLP trace exporter: %v", err)
+		logging.FromContext(ctx).Error("failed to create OTLP trace exporter", "err", err)
+		os.Exit(1)
 	}
 
 	tp := sdktrace.NewTracerProvider(


### PR DESCRIPTION
## Summary
- introduce internal logging package with context helpers
- switch wrapper to structured slog-based logging
- document structured JSON logs in README

## Testing
- `go vet ./...`
- `make test`
- `make build`
- `make quickstart`


------
https://chatgpt.com/codex/tasks/task_e_688f179601688323b7bc70aaf5aac5c7