### PR TITLE
feat(helm): add otel collector configmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,17 +152,17 @@ The wrapper is configured using the following environment variables:
 
 ## Kubernetes Deployment
 
-### Apply manifests
+### Install with Helm
 
 ```bash
-kubectl apply -f deploy/deployment.yaml
+helm install sling-sync-wrapper ./helm/sling-sync-wrapper
 ```
 
 This will deploy:
 
-- OpenTelemetry Collector (Deployment + Service).
+- OpenTelemetry Collector (Deployment + Service) and its ConfigMap.
 - Sling Sync Job (CronJob) running every 5 minutes.
-- Pipeline ConfigMap (sling-pipelines) for one or more pipeline YAMLs.
+- Pipeline ConfigMap for one or more pipeline YAMLs.
 
 Configure the CronJob using the environment variables described in the [Environment Variables](#environment-variables) section.
 

--- a/helm/sling-sync-wrapper/Chart.yaml
+++ b/helm/sling-sync-wrapper/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: sling-sync-wrapper
 description: A Helm chart for deploying the Sling Sync Wrapper in Kubernetes
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.0.0"

--- a/helm/sling-sync-wrapper/otel-collector/config.yaml
+++ b/helm/sling-sync-wrapper/otel-collector/config.yaml
@@ -1,0 +1,28 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+exporters:
+  logging:
+    loglevel: debug
+  otlp:
+    endpoint: greptimedb:4317
+    tls:
+      insecure: true
+
+processors:
+  batch:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, otlp]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, otlp]
+

--- a/helm/sling-sync-wrapper/templates/otel-collector-configmap.yaml
+++ b/helm/sling-sync-wrapper/templates/otel-collector-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+data:
+  config.yaml: |-
+{{ .Files.Get "otel-collector/config.yaml" | indent 4 }}


### PR DESCRIPTION
## Summary
- add OpenTelemetry Collector config file to Helm chart
- load collector config via new otel-collector ConfigMap template
- update Kubernetes deployment docs to use Helm chart

## Testing
- `go fmt ./...`
- `go vet ./...`
- `make test`
- `make build`
- `make quickstart`


------
https://chatgpt.com/codex/tasks/task_e_68939cf295108323893aec627aef06d4